### PR TITLE
Added 'gridColor' method to IgeTileMap2d

### DIFF
--- a/engine/core/IgeTileMap2d.js
+++ b/engine/core/IgeTileMap2d.js
@@ -20,6 +20,7 @@ var IgeTileMap2d = IgeEntity.extend({
 		this._tileHeight = tileHeight !== undefined ? tileHeight : 40;
 
 		this._drawGrid = 0;
+        this._gridColor = '#ffffff';
 	},
 
 	/**
@@ -35,6 +36,20 @@ var IgeTileMap2d = IgeEntity.extend({
 		}
 
 		return this._drawGrid;
+	},
+
+	/**
+	 * Gets / sets the color of the grid overlay. It can accepts a string
+	 * @param val
+	 * @return {*}
+	 */
+	gridColor: function (val)  {
+		if (val !== undefined) {
+			this._gridColor = val;
+			return this;
+		}
+
+		return this._gridColor;
 	},
 
 	/**
@@ -473,7 +488,7 @@ var IgeTileMap2d = IgeEntity.extend({
 
 		// Check if we need to draw the tile grid (usually for debug)
 		if (this._drawGrid > 0) {
-			ctx.strokeStyle = '#ffffff';
+			ctx.strokeStyle = this._gridColor;
 			gridCount = this._drawGrid;
 			x = -(tileWidth / 2);
 			y = -(tileHeight / 2);


### PR DESCRIPTION
We wanted a simple way to change the color of the grid for tile maps. This allows you modify the grid's color on the fly to make it less obtrusive. We will most likely add our own grid method in the long run but this helps extend the engine for now. We tested this with example **15.1-isoimages** on Chrome, Firefox, Oprea, and Safari with the method call:

```
ige.client.tileMap1.gridColor('rgba(255,255,255,0.5)');
ige.client.tileMap1.gridColor('#ffffff');
ige.client.tileMap1.gridColor('white');
```
- Allows you to specify what color / opacity the debug grid is
- You pass in a string with either: hex, css color name, rgba
