### PR TITLE
streamCreating entities again after they have been streamDestroyed

### DIFF
--- a/engine/core/IgeEntity.js
+++ b/engine/core/IgeEntity.js
@@ -3366,11 +3366,13 @@ var IgeEntity = IgeObject.extend({
 		ige.network.send('_igeStreamDestroy', [ige._currentTime, thisId], clientId);
 		
 		ige.network.stream._streamClientCreated[thisId] = ige.network.stream._streamClientCreated[thisId] || {};
+		ige.network.stream._streamClientData[thisId] = ige.network.stream._streamClientData[thisId] || {};
 
 		if (clientId) {
 			// Mark the client as having received a destroy
 			// command for this entity
 			ige.network.stream._streamClientCreated[thisId][clientId] = false;
+            ige.network.stream._streamClientData[thisId][clientId] = undefined;
 		} else {
 			// Mark all clients as having received this destroy
 			arr = ige.network.clients();
@@ -3378,6 +3380,7 @@ var IgeEntity = IgeObject.extend({
 			for (i in arr) {
 				if (arr.hasOwnProperty(i)) {
 					ige.network.stream._streamClientCreated[thisId][i] = false;
+                    ige.network.stream._streamClientData[thisId][i] = undefined;
 				}
 			}
 		}


### PR DESCRIPTION
 In my map streaming system it can happen that a 'streamDestroy' message is sent to clients for entities that have moved too far away. Such entities continue to exist on the server, but they are destroyed on the client. In case such entities come closer again, they will be re-created with a 'streamCreate' message. 

The problem that occurs then is that these clients won't receive any stream updates unless there was a change in the entity's data. If the entity just stood there the whole time, the server won't send stream updates because from his point of view the entity has not changed at all.

The solution to this is to also reset the _streamClientData field when a 'streamDestroy' message is sent to a client. (This field is used in IgeEntity._streamSync() to determine whether to send an update.)
