### PR TITLE
Fix for pathing to same tile breaking

### DIFF
--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -583,6 +583,8 @@ var IgePathComponent = IgeEventingClass.extend({
 				path._finished = true;
 				path.emit('pathComplete', [this, pointArr[path._previousPointFrom].x, pointArr[path._previousPointFrom].y]);
 			}
+		} else if(path._active && path._totalDistance == 0 && !path._finished) {
+			path._finished = true;
 		}
 	},
 	


### PR DESCRIPTION
When a path is created with the destination set to the same as the current tile. The pathing component gets into a broken state. Future paths are never followed.

If distance is zero and path is active and not finished then it should be marked as finished.
