### PR TITLE
Fix issue with pathing where it would teleport between points

### DIFF
--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -644,15 +644,19 @@ var IgePathComponent = IgeEventingClass.extend({
 	
 	_calculatePathData: function () {
 		var totalDistance = 0,
-			startPoint = this._entity._translate.clone(),
+			startPoint,
 			pointFrom,
 			pointTo,
 			i;
 
-		// always set the first point to be the current position
-		startPoint = this.unTransformPoint(startPoint);
-		startPoint = this.dividePoint(startPoint);
-		this._points[0] = startPoint;
+
+		if(this._currentPointFrom === 0) {
+			// always set the first point to be the current position
+			startPoint = this._entity._translate.clone();
+			startPoint = this.unTransformPoint(startPoint);
+			startPoint = this.dividePoint(startPoint);
+			this._points[0] = startPoint;
+		}
 
 		// Calculate total distance to travel
 		for (i = 1; i < this._points.length; i++) {


### PR DESCRIPTION
There's an issue that was reported [a while ago](http://isogenicengine.com/forum/viewtopic.php?f=5&t=169) and [again recently](http://isogenicengine.com/forum/viewtopic.php?f=5&t=352)

The pathing teleports around, this bug is related to the rebuild of the pathing about a year ago.
The pathing should always generate the first point being the entities current translation, this is not possible in the new system because it generates absolute tile coordinates instead of world points.

The solution I have come up is not perfect but it fixes the current issue.
It basically overrides the first point with the entity's current translation when the path timing data is calculated.
