### PR TITLE
Removed more depricated prefix for image smoothing

### DIFF
--- a/engine/core/IgeEntity.js
+++ b/engine/core/IgeEntity.js
@@ -140,11 +140,9 @@ var IgeEntity = IgeObject.extend({
 				var smoothing = this._cacheSmoothing !== undefined ? this._cacheSmoothing : ige._globalSmoothing;
 				if (!smoothing) {
 					this._cacheCtx.imageSmoothingEnabled = false;
-					this._cacheCtx.webkitImageSmoothingEnabled = false;
 					this._cacheCtx.mozImageSmoothingEnabled = false;
 				} else {
 					this._cacheCtx.imageSmoothingEnabled = true;
-					this._cacheCtx.webkitImageSmoothingEnabled = true;
 					this._cacheCtx.mozImageSmoothingEnabled = true;
 				}
 
@@ -212,11 +210,9 @@ var IgeEntity = IgeObject.extend({
 					var smoothing = this._cacheSmoothing !== undefined ? this._cacheSmoothing : ige._globalSmoothing;
 					if (!smoothing) {
 						this._cacheCtx.imageSmoothingEnabled = false;
-						this._cacheCtx.webkitImageSmoothingEnabled = false;
 						this._cacheCtx.mozImageSmoothingEnabled = false;
 					} else {
 						this._cacheCtx.imageSmoothingEnabled = true;
-						this._cacheCtx.webkitImageSmoothingEnabled = true;
 						this._cacheCtx.mozImageSmoothingEnabled = true;
 					}
 				}

--- a/engine/core/IgeTextureMap.js
+++ b/engine/core/IgeTextureMap.js
@@ -493,11 +493,9 @@ var IgeTextureMap = IgeTileMap2d.extend({
 			// Ensure the canvas is using the correct image antialiasing mode
 			if (!ige._globalSmoothing) {
 				sectionCtx.imageSmoothingEnabled = false;
-				sectionCtx.webkitImageSmoothingEnabled = false;
 				sectionCtx.mozImageSmoothingEnabled = false;
 			} else {
 				sectionCtx.imageSmoothingEnabled = true;
-				sectionCtx.webkitImageSmoothingEnabled = true;
 				sectionCtx.mozImageSmoothingEnabled = true;
 			}
 


### PR DESCRIPTION
Removed multiple instances of .webkitImageSmoothingEnabled to avoid console error in Chrome 54:
'CanvasRenderingContext2D.webkitImageSmoothingEnabled' is deprecated and will be removed in M55, around November 2016. Please use 'CanvasRenderingContext2D.imageSmoothingEnabled' instead. See https://www.chromestatus.com/features/5639849247768576 for more details.