### PR TITLE
IgeFontSmartTexture will now honour textAlignY properties top, middle…

### DIFF
--- a/engine/assets/IgeFontSmartTexture.js
+++ b/engine/assets/IgeFontSmartTexture.js
@@ -60,7 +60,6 @@ var IgeFontSmartTexture = {
 				i;
 
 			ctx.font = entity._nativeFont;
-			ctx.textBaseline = 'middle';
 
 			if (entity._colorOverlay) {
 				ctx.fillStyle = entity._colorOverlay;
@@ -101,11 +100,32 @@ var IgeFontSmartTexture = {
 				lineArr.push(text);
 			}
 
-			lineHeight = Math.floor(entity._bounds2d.y / lineArr.length);
-			renderStartY = -((lineHeight + (entity._textLineSpacing)) / 2) * (lineArr.length - 1);
+			// vertical text alignment
+			if (entity._textAlignY === 0) {
+				ctx.textBaseline = 'top';
+				renderStartY = -(entity._bounds2d.y / 2);
+			}
+			if (entity._textAlignY === 1) {
+				ctx.textBaseline = 'middle';
+				renderStartY = -(entity._textLineSpacing / 2) * (lineArr.length - 1);
+			}
+			if (entity._textAlignY === 2) {
+				ctx.textBaseline = 'bottom';
+				renderStartY = entity._bounds2d.y / 2 - entity._textLineSpacing * (lineArr.length - 1);
+			}
+			// Justified - lines spaced out evenly according to height
+			if (entity._textAlignY === 3) {
+				ctx.textBaseline = 'middle';
+				lineHeight = Math.floor(entity._bounds2d.y / lineArr.length);
+				renderStartY = -((lineHeight + (entity._textLineSpacing)) / 2) * (lineArr.length - 1);
+			}
 
 			for (i = 0; i < lineArr.length; i++) {
-				renderY = renderStartY + (lineHeight * i) + (entity._textLineSpacing * (i));
+				if (entity._textAlignY === 3) {
+					renderY = renderStartY + (lineHeight * i) + (entity._textLineSpacing * (i));
+				} else {
+					renderY = renderStartY + entity._textLineSpacing * i;
+				}
 
 				// Measure text
 				textSize = ctx.measureText(lineArr[i]);

--- a/engine/core/IgeFontEntity.js
+++ b/engine/core/IgeFontEntity.js
@@ -11,7 +11,7 @@ var IgeFontEntity = IgeUiEntity.extend({
 		this._renderText = undefined;
 		this._text = undefined;
 		this._textAlignX = 1;
-		this._textAlignY = 1;
+		this._textAlignY = 3;
 		this._textLineSpacing = 0;
 		this._nativeMode = false;
 
@@ -147,8 +147,9 @@ var IgeFontEntity = IgeUiEntity.extend({
 
 	/**
 	 * Gets / sets the current vertical text alignment. Accepts
-	 * a value of 0, 1 or 2 (top, middle, bottom) respectively.
-	 * @param {Number=} val
+	 * a value of 0, 1, 2, 3 (top, middle, bottom, justified) respectively.
+	 * Defaults to 3 (justified)
+	 * @param {Number} [val=3] val
 	 * @returns {*}
 	 */
 	textAlignY: function (val) {


### PR DESCRIPTION
… and bottom. Default behaviour is now a new option 3 - justified to retain backwards compatibility.

Based on old changes by @ChrisEt with @raldred 