### PR TITLE
Fix issue with _fontEntity undefined

### DIFF
--- a/engine/ui/IgeUiLabel.js
+++ b/engine/ui/IgeUiLabel.js
@@ -18,9 +18,10 @@ var IgeUiLabel = IgeUiElement.extend({
 			.left(0)
 			.middle(0)
 			.textAlignX(0)
-			.textAlignY(0)
-			.mount(this);
-		
+			.textAlignY(0);
+
+		this._fontEntity.mount(self);
+
 		// Set defaults
 		this.font('10px Verdana');
 		this.paddingLeft(5);
@@ -145,7 +146,7 @@ var IgeUiLabel = IgeUiElement.extend({
 	
 	nativeFont: function (val) {
 		if (val !== undefined) {
-			this._fontEntity.nativeFont(val);
+			// this._fontEntity.nativeFont(val);
 			return this;
 		}
 		

--- a/engine/ui/IgeUiLabel.js
+++ b/engine/ui/IgeUiLabel.js
@@ -146,7 +146,7 @@ var IgeUiLabel = IgeUiElement.extend({
 	
 	nativeFont: function (val) {
 		if (val !== undefined) {
-			// this._fontEntity.nativeFont(val);
+			this._fontEntity.nativeFont(val);
 			return this;
 		}
 		

--- a/engine/ui/IgeUiTextBox.js
+++ b/engine/ui/IgeUiTextBox.js
@@ -24,7 +24,8 @@ var IgeUiTextBox = IgeUiElement.extend({
 			.middle(0)
 			.textAlignX(0)
 			.textAlignY(0)
-			.mount(this);
+
+		this._fontEntity.mount(self);
 		
 		var blurFunc = function () {
 			if (self._domElement) {


### PR DESCRIPTION
The examples/5.1-ui got this _fontEntity undefined error, that practically make the example useless. Fixed