### PR TITLE
IgePathComponent improvements (BREAKING CHANGE)

### DIFF
--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -228,8 +228,16 @@ var IgePathComponent = IgeEventingClass.extend({
 			findNearest
 		);
 
-		this.clear();
-		this.addPoints(prePath.concat(path));
+		// Do nothing if the new path is empty or invalid
+		if (path.length > 0) {
+			this.clear();
+			this.addPoints(prePath.concat(path));
+		}
+		else
+		{
+			this.log('Cannot reroute to an empty path!', 'warning');
+		}
+
 		return this;
 	},
 

--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -196,6 +196,44 @@ var IgePathComponent = IgeEventingClass.extend({
 	},
 
 	/**
+	 * Sets a new destination for a path including the point currently being traversed if a path is active
+	 * This creates a smooth transition and flow of pointComplete events between the old and new paths
+	 * @param {Number} x The x tile to path to.
+	 * @param {Number} y The y tile to path to.
+	 * @param {Number} z The z tile to path to.
+	 * @param {Boolean=} findNearest If the destination is unreachable, when set to
+	 * true this option will allow the pathfinder to return the closest path to the
+	 * destination tile.
+	 * @returns {*}
+	 */
+	reRoute: function (x, y, z, findNearest) {
+		// Get the endPoint of the current path
+		var toPoint = this.getToPoint(),
+			fromPoint = this.getFromPoint();
+
+		if (!toPoint) {
+			// There is no existing path, detect current tile position
+			toPoint = this._entity._parent.pointToTile(this._entity._translate);
+		}
+
+		// Create a new path, making sure we include the points that we're currently working between
+		var prePath = fromPoint ? [fromPoint] : [];
+		var path = this._finder.generate(
+			this._tileMap,
+			toPoint,
+			new IgePoint3d(x, y, z),
+			this._tileChecker,
+			this._allowSquare,
+			this._allowDiagonal,
+			findNearest
+		);
+
+		this.clear();
+		this.addPoints(prePath.concat(path));
+		return this;
+	},
+
+	/**
 	 * Adds a path array containing path points (IgePoint3d instances) to the points queue.
 	 * @param {Array} path An array of path points.
 	 * @return {*}

--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -409,9 +409,12 @@ var IgePathComponent = IgeEventingClass.extend({
 			
 			this._calculatePathData();
 
-			if (this._points.length > 0) {
-				startPoint = this._points[0];
+			if (this._points.length > 1) {
 				this._nextPointToProcess = 0;
+				this._currentPointFrom = 0;
+				this._currentPointTo = 1;
+
+				startPoint = this._points[0];
 				this.emit("started", [this._entity, startPoint.x, startPoint.y, this._startTime]);
 			}
 		} else {
@@ -435,6 +438,11 @@ var IgePathComponent = IgeEventingClass.extend({
 			if (!this._active) {
 				this._active = true;
 				this._startTime = startTime || ige._currentTime;
+
+				if (this._points.length > 1) {
+					this._currentPointFrom = this._nextPointToProcess;
+					this._currentPointTo = this._nextPointToProcess + 1;
+				}
 			}
 		}
 

--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -333,13 +333,19 @@ var IgePathComponent = IgeEventingClass.extend({
 	 * @param {Number=} val
 	 * @return {*}
 	 */
-	speed: function (val) {
+	speed: function (val, startTime) {
+		var endPoint, restartPoint;
+
 		if (val !== undefined) {
 			this._speed = val / 1000;
-			
+
 			if (this._active) {
+				restartPoint = this._points[this._nextPointToProcess];
+				endPoint = this.getEndPoint();
+
 				this.stop();
-				this.start(this._startTime);
+				this.set(restartPoint.x, restartPoint.y, restartPoint.z, endPoint.x, endPoint.y, endPoint.z);
+				this.restart(startTime || ige._currentTime);
 			}
 			return this;
 		}
@@ -372,7 +378,27 @@ var IgePathComponent = IgeEventingClass.extend({
 		} else {
 			this._finished = false;
 		}
-		
+
+		return this;
+	},
+
+	/**
+	 * Restarts an existing path traversal, for example after we have changed the speed or given it a new set of points
+	 * but don't want to consider it a new path and raise a new start event
+	 * @param {Number=} startTime The time to start path traversal. Defaults
+	 * to ige._currentTime if no value is presented.
+	 * @return {*}
+	 */
+	restart: function (startTime) {
+		if (this._points.length > this._nextPointToProcess) {
+			this._finished = false;
+
+			if (!this._active) {
+				this._active = true;
+				this._startTime = startTime || ige._currentTime;
+			}
+		}
+
 		return this;
 	},
 

--- a/engine/components/IgePathComponent.js
+++ b/engine/components/IgePathComponent.js
@@ -381,8 +381,9 @@ var IgePathComponent = IgeEventingClass.extend({
 				restartPoint = this._points[this._nextPointToProcess];
 				endPoint = this.getEndPoint();
 
-				this.stop();
-				this.set(restartPoint.x, restartPoint.y, restartPoint.z, endPoint.x, endPoint.y, endPoint.z);
+				// Need to round the restart co-ordinates as the speed could have changed with an entity halfway between
+				// points and this upsets the tile checker
+				this.set(Math.round(restartPoint.x), Math.round(restartPoint.y), restartPoint.z, endPoint.x, endPoint.y, endPoint.z);
 				this.restart(startTime || ige._currentTime);
 			}
 			return this;


### PR DESCRIPTION
Apologies in advance, this one is a bit meaty! These changes are a follow on from my previous PR around allowing games to better handle jumps in engine time. 

This PR contains fixes for the following:

* IgePathComponent does not raise pointComplete or pathComplete events unless the engine is ticking in real time (fix for this could be considered a breaking change). 
* The last point of a path would never raise a pointComplete event, only a pathComplete (definitely a breaking change).
* Changing speed on an active path would result in the entity suddenly teleporting forwards as the new speed would be considered for the entire path and not just the remaining points (`restart` method was added to avoid having a pathStarted event trigger every time speed changes).
* pointComplete events are only raised when the entity reaches the middle of the tile, whereas starting a path begins from the current point regardless of position within the tile. This meant that you could button-bash to constantly start new paths and pointComplete events would never fire. (Added a new method `reroute` which starts a new path but prepends the point currently in progress to make sure we get the event)
* During the first few ticks of an entity on a new path, we were unable to obtain the path direction as _currentPointTo was not yet set

Phew!
