### PR TITLE
Improve how highlighting propagates to child entities

### DIFF
--- a/engine/core/IgeEntity.js
+++ b/engine/core/IgeEntity.js
@@ -41,8 +41,8 @@ var IgeEntity = IgeObject.extend({
 		
 		this._velocity = new IgePoint3d(0, 0, 0);
 
-        this._localMatrix = new IgeMatrix2d();
-        this._worldMatrix = new IgeMatrix2d();
+		this._localMatrix = new IgeMatrix2d();
+		this._worldMatrix = new IgeMatrix2d();
 		this._oldWorldMatrix = new IgeMatrix2d();
 
 		this._inView = true;
@@ -957,9 +957,17 @@ var IgeEntity = IgeObject.extend({
 	 * @return {*} "this" when arguments are passed to allow method
 	 * chaining or the current value if no arguments are specified.
 	 */
-	highlight: function (val) {
+	highlight: function (val, highlightChildEntities = true) {
 		if (val !== undefined) {
 			this._highlight = val;
+
+			if (highlightChildEntities) {
+				this._children.each(function (child) {
+					child.highlight(val);
+				});
+			}
+
+			this.cacheDirty(true);
 			return this;
 		}
 
@@ -3899,7 +3907,7 @@ var IgeEntity = IgeObject.extend({
 			// Mark the client as having received a destroy
 			// command for this entity
 			ige.network.stream._streamClientCreated[thisId][clientId] = false;
-            ige.network.stream._streamClientData[thisId][clientId] = undefined;
+			ige.network.stream._streamClientData[thisId][clientId] = undefined;
 		} else {
 			// Mark all clients as having received this destroy
 			arr = ige.network.clients();
@@ -3907,7 +3915,7 @@ var IgeEntity = IgeObject.extend({
 			for (i in arr) {
 				if (arr.hasOwnProperty(i)) {
 					ige.network.stream._streamClientCreated[thisId][i] = false;
-                    ige.network.stream._streamClientData[thisId][i] = undefined;
+					ige.network.stream._streamClientData[thisId][i] = undefined;
 				}
 			}
 		}

--- a/engine/core/IgeEntity.js
+++ b/engine/core/IgeEntity.js
@@ -1858,8 +1858,10 @@ var IgeEntity = IgeObject.extend({
 				texture.render(ctx, this, ige._tickDelta);
 
 				if (this._highlight) {
+					ctx.save();
 					ctx.globalCompositeOperation = this._highlightToGlobalCompositeOperation(this._highlight);
 					texture.render(ctx, this);
+					ctx.restore();
 				}
 			}
 			
@@ -1911,16 +1913,6 @@ var IgeEntity = IgeObject.extend({
 		}
 
 		ige._drawCount++;
-
-		if (this._highlight) {
-			ctx.globalCompositeOperation = this._highlightToGlobalCompositeOperation(this._highlight);
-			ctx.drawImage(
-				this._cacheCanvas,
-				-this._bounds2d.x2, -this._bounds2d.y2
-			);
-
-			ige._drawCount++;
-		}
 		ctx.restore();
 	},
 


### PR DESCRIPTION
Currently, child entities are always highlighted along with the parent because ctx.globalCompositeOperation is set when rendering the parent texture, but the context is never saved/restored so the setting remains until after we have rendered the children. 

Default behaviour of highlight function is now to iterate over child entities and apply the highlight to them directly. This can optionally be disabled so we can control highlighting of children independently if required.

The highlight logic in renderCache was removed, as this was incompatible with the new approach and even in the previous code would have had resulted in a double application of highlighting, leading to undesired effects dependent on the operation, such as absolute blacks becoming transparent.