### PR TITLE
Use Offscreen canvas class rather than creating DOM canvas nodes

### DIFF
--- a/engine/core/IgeCanvas.ts
+++ b/engine/core/IgeCanvas.ts
@@ -1,12 +1,12 @@
 import { IgeTexture } from "./IgeTexture";
 
-export interface IgeCanvas extends HTMLCanvasElement {
+export interface IgeCanvas extends OffscreenCanvas {
 	_igeTextures: IgeTexture[];
 	_loaded: boolean;
 }
 
 export const newCanvas = (): IgeCanvas => {
-	const instance = document.createElement("canvas");
+	const instance = new OffscreenCanvas(2, 2);
 
 	Object.defineProperty(instance, "_igeTextures", {
 		configurable: true,

--- a/engine/core/IgeEngine.ts
+++ b/engine/core/IgeEngine.ts
@@ -372,10 +372,10 @@ export class IgeEngine extends IgeEntity {
 		// current ige settings if no options are provided. This is a
 		// safe way to generate a new canvas for things like caching
 		// stores or whatever
-		const canvas = document.createElement("canvas");
+		const canvas = new OffscreenCanvas(2, 2);
 
 		// Get the context
-		const ctx = canvas.getContext("2d");
+		const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 		if (!ctx) {
 			throw new Error("Could not get canvas rendering context!");
@@ -397,7 +397,7 @@ export class IgeEngine extends IgeEntity {
 		};
 	}
 
-	_setInternalCanvasSize (canvas: HTMLCanvasElement | IgeDummyCanvas, ctx: IgeCanvasRenderingContext2d, newWidth: number, newHeight: number) {
+	_setInternalCanvasSize (canvas: OffscreenCanvas | IgeDummyCanvas, ctx: IgeCanvasRenderingContext2d, newWidth: number, newHeight: number) {
 		canvas.width = newWidth * this._deviceFinalDrawRatio;
 		canvas.height = newHeight * this._deviceFinalDrawRatio;
 

--- a/engine/core/IgeFontSheet.ts
+++ b/engine/core/IgeFontSheet.ts
@@ -53,8 +53,8 @@ export class IgeFontSheet extends IgeTexture {
 
 	decodeHeader () {
 		// Create a temporary canvas
-		const canvas = document.createElement("canvas"),
-			ctx = canvas.getContext("2d");
+		const canvas = new OffscreenCanvas(2, 2),
+			ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 		// Set canvas width to match font sheet image and
 		// height to 1 as we have 1 line of header data

--- a/engine/core/IgeObject.ts
+++ b/engine/core/IgeObject.ts
@@ -121,7 +121,7 @@ export class IgeObject extends IgeEventingClass implements IgeCanRegisterById, I
 	_hidden: boolean;
 	_cache: boolean = false;
 	_cacheCtx?: IgeCanvasRenderingContext2d | null;
-	_cacheCanvas?: HTMLCanvasElement | IgeDummyCanvas;
+	_cacheCanvas?: OffscreenCanvas | IgeDummyCanvas;
 	_cacheDirty: boolean = false;
 	_cacheSmoothing: boolean = false;
 	_aabbDirty: boolean = false;

--- a/engine/core/IgeSpriteSheet.ts
+++ b/engine/core/IgeSpriteSheet.ts
@@ -114,8 +114,8 @@ export class IgeSpriteSheet extends IgeTexture {
      */
 	detectCells (img: IgeImage | IgeCanvas): IgeTextureCellArray {
 		// Create a temp canvas
-		const canvas = document.createElement("canvas");
-		const ctx = canvas.getContext("2d");
+		const canvas = new OffscreenCanvas(1, 1);
+		const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 		const spriteRects = [];
 
 		if (!ctx) {

--- a/engine/core/IgeTexture.ts
+++ b/engine/core/IgeTexture.ts
@@ -389,7 +389,7 @@ export class IgeTexture extends IgeAsset {
 
 			this._textureCanvas.width = x;
 			this._textureCanvas.height = y;
-			const tmpCtx = this._textureCanvas.getContext("2d");
+			const tmpCtx = this._textureCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!tmpCtx) {
 				throw new Error("Couldn't get texture canvas 2d context!");
@@ -452,7 +452,7 @@ export class IgeTexture extends IgeAsset {
 
 		this._textureCanvas.width = x;
 		this._textureCanvas.height = y;
-		const tmpCtx = this._textureCanvas.getContext("2d");
+		const tmpCtx = this._textureCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 		if (!tmpCtx) {
 			throw new Error("Couldn't get texture canvas 2d context!");
@@ -675,7 +675,7 @@ export class IgeTexture extends IgeAsset {
 
 			this._textureCanvas.width = this._originalImage.width;
 			this._textureCanvas.height = this._originalImage.height;
-			const tmpCtx = this._textureCanvas.getContext("2d");
+			const tmpCtx = this._textureCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!tmpCtx) {
 				throw new Error("Couldn't get texture canvas 2d context!");
@@ -721,7 +721,7 @@ export class IgeTexture extends IgeAsset {
 
 			this._textureCanvas.width = this._originalImage.width;
 			this._textureCanvas.height = this._originalImage.height;
-			const tmpCtx = this._textureCanvas.getContext("2d");
+			const tmpCtx = this._textureCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!tmpCtx) {
 				throw new Error("Couldn't get texture canvas 2d context!");
@@ -779,7 +779,7 @@ export class IgeTexture extends IgeAsset {
 
 			this._textureCanvas.width = this.image.width;
 			this._textureCanvas.height = this.image.height;
-			const tmpCtx = this._textureCanvas.getContext("2d");
+			const tmpCtx = this._textureCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!tmpCtx) {
 				throw new Error("Couldn't get texture canvas 2d context!");
@@ -887,7 +887,7 @@ export class IgeTexture extends IgeAsset {
 		const canvas = newCanvas();
 		if (!canvas) return;
 
-		const ctx = canvas.getContext("2d");
+		const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 		if (!ctx) {
 			throw new Error("Unable to get 2d context from IgeTexture canvas");

--- a/engine/core/IgeTextureMap.ts
+++ b/engine/core/IgeTextureMap.ts
@@ -493,19 +493,17 @@ export class IgeTextureMap extends IgeTileMap2d {
 		this._sectionCtx[sectionX] = this._sectionCtx[sectionX] || [];
 
 		if (!this._sections[sectionX][sectionY]) {
-			this._sections[sectionX][sectionY] = document.createElement("canvas");
+			this._sections[sectionX][sectionY] = new OffscreenCanvas(2, 2);
 			this._sections[sectionX][sectionY].width = (this._tileWidth * this._autoSection);
 			this._sections[sectionX][sectionY].height = (this._tileHeight * this._autoSection);
 
-			sectionCtx = this._sectionCtx[sectionX][sectionY] = this._sections[sectionX][sectionY].getContext("2d");
+			sectionCtx = this._sectionCtx[sectionX][sectionY] = this._sections[sectionX][sectionY].getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			// Ensure the canvas is using the correct image antialiasing mode
 			if (!this._ige._globalSmoothing) {
 				sectionCtx.imageSmoothingEnabled = false;
-				sectionCtx.mozImageSmoothingEnabled = false;
 			} else {
 				sectionCtx.imageSmoothingEnabled = true;
-				sectionCtx.mozImageSmoothingEnabled = true;
 			}
 
 			// One-time translate the context

--- a/engine/core/IgeUiEntity.ts
+++ b/engine/core/IgeUiEntity.ts
@@ -1154,8 +1154,8 @@ export class IgeUiEntity extends IgeEntity {
 		if (this._cell && this._cell > 1) {
 			// We are using a cell sheet, render the cell to a
 			// temporary canvas and set that as the pattern image
-			const canvas = document.createElement("canvas");
-			const ctx = canvas.getContext("2d");
+			const canvas = new OffscreenCanvas(2, 2);
+			const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!ctx) {
 				throw new Error("Couldn't get texture canvas 2d context!");

--- a/engine/filters/glowMask.ts
+++ b/engine/filters/glowMask.ts
@@ -27,8 +27,8 @@ export const glowMask: IgeSmartFilter = function (canvas, ctx, originalImage, te
 
 		if (!pixelData) return;
 
-		tempCanvas = document.createElement("canvas");
-		tempCtx = tempCanvas.getContext("2d");
+		tempCanvas = new OffscreenCanvas(2, 2);
+		tempCtx = tempCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 		tempCanvas.width = canvas.width;
 		tempCanvas.height = canvas.height;

--- a/engine/igeFilters.ts
+++ b/engine/igeFilters.ts
@@ -7,7 +7,7 @@ export type IgeFilterHelperFunction = (...args: any[]) => any;
 export class IgeFilters {
 	filter: Record<string, IgeSmartFilter> = {};
 	helper: Record<string, IgeFilterHelperFunction> = {};
-	tmpCanvas?: HTMLCanvasElement;
+	tmpCanvas?: OffscreenCanvas;
 	tmpCtx?: IgeCanvasRenderingContext2d | null;
 
 	constructor () {
@@ -15,8 +15,8 @@ export class IgeFilters {
 			return;
 		}
 
-		this.tmpCanvas = document.createElement("canvas");
-		this.tmpCtx = this.tmpCanvas.getContext("2d");
+		this.tmpCanvas = new OffscreenCanvas(2, 2);
+		this.tmpCtx = this.tmpCanvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 	}
 
 	getFilter (name: string): IgeSmartFilter | undefined {

--- a/engine/mixins/IgeUiStyleMixin.ts
+++ b/engine/mixins/IgeUiStyleMixin.ts
@@ -103,8 +103,8 @@ export const WithUiStyleMixin = <BaseClassType extends Mixin<IgeObject>>(Base: B
 		if (this._cell && this._cell > 1) {
 			// We are using a cell sheet, render the cell to a
 			// temporary canvas and set that as the pattern image
-			const canvas = document.createElement("canvas");
-			const ctx = canvas.getContext("2d");
+			const canvas = new OffscreenCanvas(2, 2);
+			const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!ctx) {
 				throw new Error("Couldn't get texture canvas 2d context!");

--- a/engine/textures/IgeFontSmartTexture.ts
+++ b/engine/textures/IgeFontSmartTexture.ts
@@ -106,8 +106,8 @@ export const IgeFontSmartTexture: IgeSmartTexture = {
 				return -1;
 			}
 
-			const canvas = document.createElement("canvas");
-			const ctx = canvas.getContext("2d");
+			const canvas = new OffscreenCanvas(2, 2);
+			const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			if (!ctx) {
 				throw new Error("measureTextWidth() failed to get a canvas 2d context to work with!");

--- a/starFlight/assets/IgeFontSmartTexture.ts
+++ b/starFlight/assets/IgeFontSmartTexture.ts
@@ -11,8 +11,8 @@ export const IgeFontSmartTexture: IgeSmartTexture = {
 				lineIndex,
 				measuredWidth,
 				maxWidth = 0,
-				canvas = document.createElement("canvas"),
-				ctx = canvas.getContext("2d");
+				canvas = new OffscreenCanvas(2, 2),
+				ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
 			// Handle multi-line text
 			if (text.indexOf("\n") > -1) {

--- a/types/IgeCanvasRenderingContext2d.ts
+++ b/types/IgeCanvasRenderingContext2d.ts
@@ -1,3 +1,3 @@
 import { IgeDummyContext } from "@/engine/core/IgeDummyContext";
 
-export type IgeCanvasRenderingContext2d = CanvasRenderingContext2D | IgeDummyContext;
+export type IgeCanvasRenderingContext2d = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | IgeDummyContext;

--- a/types/IgeSmartFilter.ts
+++ b/types/IgeSmartFilter.ts
@@ -4,7 +4,7 @@ import { IgeCanvas } from "@/engine/core/IgeCanvas";
 import { IgeCanvasRenderingContext2d } from "./IgeCanvasRenderingContext2d";
 
 export type IgeSmartFilter = (
-    canvas: HTMLCanvasElement,
+    canvas: OffscreenCanvas,
     ctx: IgeCanvasRenderingContext2d,
     originalImage: IgeImage | IgeCanvas,
     texture: IgeTexture,


### PR DESCRIPTION
Large numbers of DOM nodes get to a point where performance drops off a cliff and leads to crashes. Using OffscreenCanvas prevents this issue and also reduces game loading times significantly. It's also supported by Web Workers.

P.S Welcome back Rob!